### PR TITLE
add generic harvester patch.

### DIFF
--- a/Extras/SystemHeatHarvesters/genericHarvesters.cfg
+++ b/Extras/SystemHeatHarvesters/genericHarvesters.cfg
@@ -16,7 +16,7 @@
 		moduleID = #$ConverterName$ //this should be the localization string or the actual name, either way, unique.
 		systemHeatModuleID = harvester
 		shutdownTemperature = 750
-		systemOutletTemperature = 400
+		systemOutletTemperature = 350
 		systemEfficiency
 		{
 			key = 0 1.0

--- a/Extras/SystemHeatHarvesters/genericHarvesters.cfg
+++ b/Extras/SystemHeatHarvesters/genericHarvesters.cfg
@@ -1,0 +1,33 @@
+@PART[*]:HAS[@MODULE[ModuleResourceHarvester]:HAS[@INPUT_RESOURCE:HAS[#ResourceName[ElectricCharge]]]]:FINAL{ //really need final.
+	!MODULE[ModuleCoreHeat] {}
+	%MODULE[ModuleSystemHeat]
+	{
+		%name = ModuleSystemHeat
+		// Cubic metres
+		%volume = #$/mass$ //1 ton equals 1 cubic meter of cooling. it *very roughly* approximates the balance of squads ISRU
+		%moduleID = harvester
+		%iconName = Icon_Drill
+	}
+
+	!MODULE[ModuleOverheatDisplay]{}
+
+	@MODULE[ModuleResourceHarvester]:HAS[@INPUT_RESOURCE:HAS[#ResourceName[ElectricCharge]]]{ //Ive seen some converters that dont use electric charge, those things need thier own patch, as we calculate produced heat based on EC consumption.
+		@name = ModuleSystemHeatHarvester
+		moduleID = #$ConverterName$ //this should be the localization string or the actual name, either way, unique.
+		systemHeatModuleID = harvester
+		shutdownTemperature = 750
+		systemOutletTemperature = 400
+		systemEfficiency
+		{
+			key = 0 1.0
+			key = 350 0.5
+			key = 750 0.0
+		}
+		systemPower = #$INPUT_RESOURCE:HAS[#ResourceName[ElectricCharge]]/Ratio$
+		@systemPower *= #$Efficiency$ //set the heat ouput as proportional to the EC usage.
+		// I *think* that all the energy goes into heat.
+		!Thermalefficiency {}
+		!TemperatureModifier {}
+		@generatesHeat = false //disable stock heating
+	}
+}


### PR DESCRIPTION
Again, ignores modules that are already systemHeatHarvesters.

One thing I found is that the patched squad parts output more heat than they consume in electricity. I did reduce the outlet temp to compensate.

Turns out I only had to modify a few things to apply the converter patch to drills.