### PR TITLE
Specify version file name in vrefs

### DIFF
--- a/CKAN/SystemHeat-Converters.netkan
+++ b/CKAN/SystemHeat-Converters.netkan
@@ -3,7 +3,7 @@
     "identifier":   "SystemHeat-Converters",
     "name":         "System Heat - Resource Converter Configuration",
     "$kref":        "#/ckan/github/post-kerbin-mining-corporation/SystemHeat",
-    "$vref":        "#/ckan/ksp-avc",
+    "$vref":        "#/ckan/ksp-avc/SystemHeat.version",
     "abstract": "This System Heat config package changes stock and mod Resource Converters to use the System Heat backend. WARNING: potentially vessel-breaking.",
     "author": "Nertea (Chris Adderley)",
     "license":      "CC-BY-NC-SA-4.0",

--- a/CKAN/SystemHeat-FissionEngines.netkan
+++ b/CKAN/SystemHeat-FissionEngines.netkan
@@ -3,7 +3,7 @@
     "identifier":   "SystemHeat-FissionEngines",
     "name":         "System Heat - Nuclear Engine Configuration",
     "$kref":        "#/ckan/github/post-kerbin-mining-corporation/SystemHeat",
-    "$vref":        "#/ckan/ksp-avc",
+    "$vref":        "#/ckan/ksp-avc/SystemHeat.version",
     "abstract": "This System Heat config package changes nuclear thermal engines to use the System Heat backend. WARNING: potentially vessel-breaking.",
     "author": "Nertea (Chris Adderley)",
     "license":      "CC-BY-NC-SA-4.0",

--- a/CKAN/SystemHeat-FissionReactors.netkan
+++ b/CKAN/SystemHeat-FissionReactors.netkan
@@ -3,7 +3,7 @@
     "identifier":   "SystemHeat-FissionReactors",
     "name":         "System Heat - Nuclear Reactor Configuration",
     "$kref":        "#/ckan/github/post-kerbin-mining-corporation/SystemHeat",
-    "$vref":        "#/ckan/ksp-avc",
+    "$vref":        "#/ckan/ksp-avc/SystemHeat.version",
     "abstract": "This System Heat configuration pack modifies nuclear reactors to use the SystemHeat backend. This principally applies to Near Future Electrical reactors. WARNING: potentially vessel-breaking.",
     "author": "Nertea (Chris Adderley)",
     "license":      "CC-BY-NC-SA-4.0",

--- a/CKAN/SystemHeat-Harvesters.netkan
+++ b/CKAN/SystemHeat-Harvesters.netkan
@@ -3,7 +3,7 @@
     "identifier":   "SystemHeat-Harvesters",
     "name":         "System Heat - Resource Harvester Configuration",
     "$kref":        "#/ckan/github/post-kerbin-mining-corporation/SystemHeat",
-    "$vref":        "#/ckan/ksp-avc",
+    "$vref":        "#/ckan/ksp-avc/SystemHeat.version",
     "abstract": "This System Heat config package changes stock and mod Resource Harvesters to use the SystemHeat backend. WARNING: potentially vessel-breaking.",
     "author": "Nertea (Chris Adderley)",
     "license":      "CC-BY-NC-SA-4.0",


### PR DESCRIPTION
Hi @ChrisAdderley,

The secondary SystemHeat modules haven't made it into CKAN for the latest release:

![image](https://user-images.githubusercontent.com/1559108/122991698-f37d4780-d36a-11eb-81d6-ff2b93dc7d62.png)

With the addition of CRP, there are now two version files in the ZIP, and netkan needs to know which one to use. This PR tells it.

(The main `SystemHeat` module is fine because it _installs_ `SystemHeat.version`, which makes it take precedence. These side modules don't install that file, so it is treated as equal in importance to CRP.version, hence the ambiguity.)

If you're interested in some automated tooling that would catch problems like this, it's possible to validate these metanetkans with GitHub workflows using the main CKAN pull request validation Action:

- https://github.com/KSP-CKAN/xKAN-meta_testing

May fix #68.