### PR TITLE
More-sophisticated cooling costs for SystemHeatBoiloff patch

### DIFF
--- a/Extras/SystemHeatBoiloff/CryoTanks/CryoTanksSystemHeat.cfg
+++ b/Extras/SystemHeatBoiloff/CryoTanks/CryoTanksSystemHeat.cfg
@@ -9,22 +9,57 @@
     iconName = Icon_Snow
   }
 
+  // FFT fusion-fuel tanks have CoolingCost specified at the module level, but
+  // CoolingHeatCost will be specified at the BOILOFFCONFIG level since it
+  // differs between the two resources.  Delete the module-level CoolingCost
+  // so it doesn't produce a module-level CoolingHeatCost.
+  @MODULE[ModuleCryoTank]:HAS[@BOILOFFCONFIG:HAS[#FuelName[LqdHe3]|#FuelName[LqdHydrogen]]]
+  {
+    !CoolingCost = deleted
+  }
+
+  // For the other resources, the cost can vary from part to part since there
+  // are both ZBO and non-ZBO tanks, so the CoolingHeatCost can't be a
+  // constant; it's derived from the CoolingCost.  It can be specified either
+  // at the module level or within a BOILOFFCONFIG; this handles the former.
+  @MODULE[ModuleCryoTank]:HAS[#CoolingCost]
+  {
+    CoolingHeatCost = #$CoolingCost$
+    @CoolingHeatCost *= 10
+    @CoolingHeatCost /= 3
+  }
+
   @MODULE[ModuleCryoTank]
   {
 
+    // Replace the basic CryoTanks cooling (consumes EC according to
+    // CoolingCost) with SystemHeat cooling (participates in a cooling loop
+    // according to CoolingHeatCost).
     @name = ModuleSystemHeatCryoTank
     systemHeatModuleID = tank
 
+    // Derive CoolingHeatCost from CoolingCost at the individual resource
+    // level, where applicable.  (Costs specified at the module level were
+    // handled earlier.)
+    @BOILOFFCONFIG:HAS[#CoolingCost]
+    {
+      CoolingHeatCost = #$CoolingCost$
+      @CoolingHeatCost *= 10
+      @CoolingHeatCost /= 3
+    }
+
     @BOILOFFCONFIG:HAS[#FuelName[LqdHydrogen]]
     {
-      CoolingHeatCost = 0.3
       CryocoolerTemperature = 300
     }
     @BOILOFFCONFIG:HAS[#FuelName[LqdMethane]]
     {
-      CoolingHeatCost = 0.15
       CryocoolerTemperature = 400
     }
+
+    // FFT fusion fuels are stored in special tanks, with a different ratio
+    // from CoolingCost to CoolingHeatCost.  These tanks don't have separate
+    // ZBO and non-ZBO versions, so the the cooling cost is always the same.
     @BOILOFFCONFIG:HAS[#FuelName[LqdHe3]]
     {
       CoolingHeatCost = 0.22


### PR DESCRIPTION
The SystemHeatBoiloff patch was using the same CoolingHeatCost values (per resource) for all parts, which meant that the CryoTanks ZBO tanks had no advantage over regular tanks, despite being more expensive.  In the basic non-SystemHeat configuration, the ZBO tanks have a lower CoolingCost, so I've changed the SystemHeatPatch to compute the CoolingHeatCost in proportion.  The ratio is such that non-ZBO tanks end up with the same CoolingHeatCost values as before, and ZBO tanks get better (since this won't break existing designs; doing it the other way would mean some craft might no longer have enough cooling.)

The fusion fuels from Far Future Tech are a different story, since they go in special tanks that don't have separate ZBO and non-ZBO versions, and the ratio from CoolingCost to CoolingHeatCost is different than for the chemical fuels.  The fixed CoolingHeatCost isn't a problem for those, so I've left it as-is.

Fixes #99