### PR TITLE
Use MaximumBoiloffScale in cryo tank boiloff radiation calculations.

### DIFF
--- a/SystemHeat/SystemHeat/Modules/ModuleSystemHeatCryoTank.cs
+++ b/SystemHeat/SystemHeat/Modules/ModuleSystemHeatCryoTank.cs
@@ -599,7 +599,7 @@ namespace SystemHeat
 
       if (ShortwaveFluxAffectsBoiloff || LongwaveFluxAffectsBoiloff)
       {
-        fluxScale = Math.Max((planetFlux / LongwaveFluxBaseline + (solarFlux * Albedo) / ShortwaveFluxBaseline) / 2.0f, MinimumBoiloffScale);
+        fluxScale = Math.Min(Math.Max((planetFlux / LongwaveFluxBaseline + (solarFlux * Albedo) / ShortwaveFluxBaseline) / 2.0f, MinimumBoiloffScale), MaximumBoiloffScale);
       }
       else
       {


### PR DESCRIPTION
The previous radiative boiloff code clamped radiative effects to `MinimumBoiloffScale`, but left `MaximumBoiloffScale` unused. This seems to have been an oversight in the original CryoTanks implementation.

Having an upper bound is essential to playing cryo tanks with `LongwaveFluxAffectsBoiloff`, because the KSP body flux has unphysical orientation-dependent spikes (100-1000× solar).

This PR should be released together with post-kerbin-mining-corporation/CryoTanks#132, to maintain consistency.