### PR TITLE
fixes Nerv and Stubber from KerbalAtomics not contributing to heat loop

### DIFF
--- a/Extras/SystemHeatFissionEngines/KerbalAtomics/ntr-sc-125-2.cfg
+++ b/Extras/SystemHeatFissionEngines/KerbalAtomics/ntr-sc-125-2.cfg
@@ -13,6 +13,14 @@
     @heatProduction = 0
   }
 
+
+  MODULE
+  {
+    name = ModuleSystemHeat
+    volume = 1
+    moduleID = reactor
+    iconName = Icon_Nuclear
+  }
   RESOURCE
   {
     name = EnrichedUranium

--- a/Extras/SystemHeatFissionEngines/Squad/nuclearEngine.cfg
+++ b/Extras/SystemHeatFissionEngines/Squad/nuclearEngine.cfg
@@ -13,6 +13,13 @@
   }
 
 
+  MODULE
+  {
+    name = ModuleSystemHeat
+    volume = 1
+    moduleID = reactor
+    iconName = Icon_Nuclear
+  }
   RESOURCE
   {
     name = EnrichedUranium


### PR DESCRIPTION
Nerv and Stubber now show up as reactors and contribute heat to the heat loop instead of just not doing anything and hitting max temp.