### PR TITLE
Fix deuterium FuelName in SystemHeatBoiloff patch

### DIFF
--- a/Extras/SystemHeatBoiloff/CryoTanks/CryoTanksSystemHeat.cfg
+++ b/Extras/SystemHeatBoiloff/CryoTanks/CryoTanksSystemHeat.cfg
@@ -13,7 +13,7 @@
   // CoolingHeatCost will be specified at the BOILOFFCONFIG level since it
   // differs between the two resources.  Delete the module-level CoolingCost
   // so it doesn't produce a module-level CoolingHeatCost.
-  @MODULE[ModuleCryoTank]:HAS[@BOILOFFCONFIG:HAS[#FuelName[LqdHe3]|#FuelName[LqdHydrogen]]]
+  @MODULE[ModuleCryoTank]:HAS[@BOILOFFCONFIG:HAS[#FuelName[LqdHe3]|#FuelName[LqdDeuterium]]]
   {
     !CoolingCost = deleted
   }


### PR DESCRIPTION
The patch that deletes module-level CoolingCost is meant to apply to Far Future Tech fusion tanks, which hold LqdDeuterium, not LqdHydrogen.  The mistake didn't really hurt anything, since those tanks also hold LqdHe3 (so they get the patch anyway) and there aren't (and shouldn't be) any non-fusion cryo tanks with CoolingCost defined on the module itself (rather than in a BOILOFFCONFIG).  Still, the patch ought to specify the correct matching criteria for the modules it intends to modify.