### PR TITLE
Implemented System Heat for the stock drills' asteroid and comet modes (modules?).

### DIFF
--- a/Extras/SystemHeatHarvesters/Squad/SystemHeatDrill.cfg
+++ b/Extras/SystemHeatHarvesters/Squad/SystemHeatDrill.cfg
@@ -155,7 +155,7 @@
     @GeneratesHeat = false
   }
 
-    @MODULE[ModuleAsteroidDrill]
+  @MODULE[ModuleAsteroidDrill]
   {
     @name = ModuleSystemHeatAsteroidHarvester
     // must be unique

--- a/Extras/SystemHeatHarvesters/Squad/SystemHeatDrill.cfg
+++ b/Extras/SystemHeatHarvesters/Squad/SystemHeatDrill.cfg
@@ -45,6 +45,68 @@
     
     @GeneratesHeat = false
   }
+
+  @MODULE[ModuleAsteroidDrill]
+  {
+    @name = ModuleSystemHeatAsteroidHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 60
+    
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  @MODULE[ModuleCometDrill]
+  {
+    @name = ModuleSystemHeatCometHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 60
+    
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
 }
 
 // Small drill
@@ -65,6 +127,68 @@
   @MODULE[ModuleResourceHarvester]
   {
     @name = ModuleSystemHeatHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 30
+    
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+    @MODULE[ModuleAsteroidDrill]
+  {
+    @name = ModuleSystemHeatAsteroidHarvester
+    // must be unique
+    moduleID = harvester
+    // ModuleSystemHeat moduleID to link to
+    systemHeatModuleID = harvester
+
+    // The shutdown temperature of the part
+    shutdownTemperature = 750
+
+    // The temperature the system contributes to loops
+    systemOutletTemperature = 400
+
+    // Map loop temperature to system efficiency (0-1.0)
+    systemEfficiency
+    {
+        key = 0 1.0
+        key = 400 1.0
+        key = 650 0.0
+    }
+    
+    // Heat generation (kW)
+    systemPower = 30
+    
+    !ThermalEfficiency  {} 
+    !TemperatureModifier {}
+    
+    @GeneratesHeat = false
+  }
+
+  @MODULE[ModuleCometDrill]
+  {
+    @name = ModuleSystemHeatCometHarvester
     // must be unique
     moduleID = harvester
     // ModuleSystemHeat moduleID to link to

--- a/SystemHeat/SystemHeat/Modules/ModuleSystemHeatCometHarvester.cs
+++ b/SystemHeat/SystemHeat/Modules/ModuleSystemHeatCometHarvester.cs
@@ -8,9 +8,9 @@ using KSP.Localization;
 namespace SystemHeat
 {
   /// <summary>
-  /// The connection between a stock ModuleAsteroidDrill and the SystemHeat system
+  /// The connection between a stock ModuleCometDrill and the SystemHeat system
   /// </summary>
-  public class ModuleSystemHeatAsteroidHarvester : ModuleAsteroidDrill
+  public class ModuleSystemHeatCometHarvester : ModuleCometDrill
   {
     // This should be unique on the part
     [KSPField(isPersistant = false)]
@@ -88,7 +88,7 @@ namespace SystemHeat
         //this.CurrentSafetyOverride = this.NominalTemperature;
       }
 
-      Utils.Log("[ModuleSystemHeatAsteroidHarvester] Setup completed", LogType.Modules);
+      Utils.Log("[ModuleSystemHeatCometHarvester] Setup completed", LogType.Modules);
 
       Events["ToggleEditorThermalSim"].guiName = Localizer.Format("#LOC_SystemHeat_ModuleSystemHeatHarvester_Field_SimulateEditor", base.ConverterName);
       Fields["HarvesterEfficiency"].guiName = Localizer.Format("#LOC_SystemHeat_ModuleSystemHeatHarvester_Field_Efficiency", base.ConverterName);

--- a/SystemHeat/SystemHeat/Modules/ModuleSystemHeatHarvester.cs
+++ b/SystemHeat/SystemHeat/Modules/ModuleSystemHeatHarvester.cs
@@ -27,6 +27,7 @@ namespace SystemHeat
     // Map system outlet temperature (K) to heat generation (kW)
     [KSPField(isPersistant = false)]
     public float systemPower = 0f;
+    
     // 
     [KSPField(isPersistant = false)]
     public float shutdownTemperature = 1000f;

--- a/SystemHeat/SystemHeat/SystemHeat.csproj
+++ b/SystemHeat/SystemHeat/SystemHeat.csproj
@@ -134,6 +134,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Modules\ModuleSystemHeatAsteroidHarvester.cs" />
+    <Compile Include="Modules\ModuleSystemHeatCometHarvester.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
- Created **ModuleSystemHeatCometHarvester.cs**, equivalent to **ModuleSystemHeatHarvester.cs** 
  - Changed **SystemHeat.csproj** to include **ModuleSystemHeatCometHarvester.cs**
- Changed **ModuleSystemHeatAsteroidHarvester.cs** to match **ModuleSystemHeatHarvester.cs**
- Changed **SystemHeatDrill.cfg** to implement system heat for asteroid and comet modules for both stock drills

- Added an empty line in **ModuleSystemHeatHarvester.cs** for consistency.

Issue: https://github.com/post-kerbin-mining-corporation/SystemHeat/issues/66