### PR TITLE
Fix suggestion identifiers

### DIFF
--- a/CKAN/SystemHeat-Converters.netkan
+++ b/CKAN/SystemHeat-Converters.netkan
@@ -16,9 +16,9 @@
         { "name": "SystemHeat"   }
     ],
     "suggests": [
-        { "name": "SystemHeatFissionReactors"   },
-        { "name": "SystemHeatFissionEngines"   },
-        { "name": "SystemHeatHarvesters"   }
+        { "name": "SystemHeat-FissionReactors"   },
+        { "name": "SystemHeat-FissionEngines"   },
+        { "name": "SystemHeat-Harvesters"   }
     ],
     "install": [ {
         "find":       "SystemHeatConverters",

--- a/CKAN/SystemHeat-CryoTanks.netkan
+++ b/CKAN/SystemHeat-CryoTanks.netkan
@@ -17,9 +17,9 @@
         { "name": "CommunityResourcePack"   }
     ],
     "suggests": [
-        { "name": "SystemHeatConverters"   },
-        { "name": "SystemHeatFissionReactors"   },
-        { "name": "SystemHeatHarvesters"   },
+        { "name": "SystemHeat-Converters"   },
+        { "name": "SystemHeat-FissionReactors"   },
+        { "name": "SystemHeat-Harvesters"   },
         { "name": "NearFuturePropulsion"   }
     ],
     "install": [ {

--- a/CKAN/SystemHeat-FissionEngines.netkan
+++ b/CKAN/SystemHeat-FissionEngines.netkan
@@ -17,9 +17,9 @@
         { "name": "CommunityResourcePack"   }
     ],
     "suggests": [
-        { "name": "SystemHeatConverters"   },
-        { "name": "SystemHeatFissionReactors"   },
-        { "name": "SystemHeatHarvesters"   },
+        { "name": "SystemHeat-Converters"   },
+        { "name": "SystemHeat-FissionReactors"   },
+        { "name": "SystemHeat-Harvesters"   },
         { "name": "KerbalAtomics"   }
     ],
     "conflicts": [

--- a/CKAN/SystemHeat-FissionReactors.netkan
+++ b/CKAN/SystemHeat-FissionReactors.netkan
@@ -20,10 +20,9 @@
         { "name": "NearFutureElectrical"   }
     ],
     "suggests": [
-        { "name": "SystemHeatConverters"   },
-        { "name": "SystemHeatFissionEngines"   },
-        { "name": "SystemHeatHarvesters"   }
-        
+        { "name": "SystemHeat-Converters"   },
+        { "name": "SystemHeat-FissionEngines"   },
+        { "name": "SystemHeat-Harvesters"   }
     ],
     "install": [ {
         "find":       "SystemHeatFissionReactors",

--- a/CKAN/SystemHeat-Harvesters.netkan
+++ b/CKAN/SystemHeat-Harvesters.netkan
@@ -16,9 +16,9 @@
         { "name": "SystemHeat"   }
     ],
     "suggests": [
-        { "name": "SystemHeatConverters"   },
-        { "name": "SystemHeatFissionReactors"   },
-        { "name": "SystemHeatFissionEngines"   }
+        { "name": "SystemHeat-Converters"   },
+        { "name": "SystemHeat-FissionReactors"   },
+        { "name": "SystemHeat-FissionEngines"   }
     ],
     "install": [ {
         "find":       "SystemHeatHarvesters",

--- a/CKAN/SystemHeat-IonEngines.netkan
+++ b/CKAN/SystemHeat-IonEngines.netkan
@@ -17,9 +17,9 @@
         { "name": "CommunityResourcePack"   }
     ],
     "suggests": [
-        { "name": "SystemHeatConverters"   },
-        { "name": "SystemHeatFissionReactors"   },
-        { "name": "SystemHeatHarvesters"   },
+        { "name": "SystemHeat-Converters"   },
+        { "name": "SystemHeat-FissionReactors"   },
+        { "name": "SystemHeat-Harvesters"   },
         { "name": "NearFuturePropulsion"   }
     ],
     "install": [ {

--- a/CKAN/SystemHeat.netkan
+++ b/CKAN/SystemHeat.netkan
@@ -18,10 +18,10 @@
         { "name": "HeatControl"   }
     ],
     "suggests": [
-        { "name": "SystemHeatConverters"   },
-        { "name": "SystemHeatFissionReactors"   },
-        { "name": "SystemHeatFissionEngines"   },
-        { "name": "SystemHeatHarvesters"   }
+        { "name": "SystemHeat-Converters"   },
+        { "name": "SystemHeat-FissionReactors"   },
+        { "name": "SystemHeat-FissionEngines"   },
+        { "name": "SystemHeat-Harvesters"   }
     ],
     "install": [ {
         "find":       "SystemHeat",


### PR DESCRIPTION
Hi @ChrisAdderley,

I was testing some CKAN changes and noticed that these mods have several suggestions that aren't working because their identifiers are missing dash characters.

![image](https://github.com/user-attachments/assets/9b433c86-e458-45a9-93a8-7801b1d738d5)

Now they're fixed.

Cheers!
