### PR TITLE
Use Correct Negative Flux Function in HeatLoop

### DIFF
--- a/SystemHeat/SystemHeat/HeatLoop.cs
+++ b/SystemHeat/SystemHeat/HeatLoop.cs
@@ -196,7 +196,7 @@ namespace SystemHeat
       return currentPosFlux;
     }
     /// <summary>
-    /// Calculates the total positive flux of the loop
+    /// Calculates the total negative flux of the loop
     /// </summary>
     protected float CalculateNegativeFlux()
     {
@@ -220,7 +220,7 @@ namespace SystemHeat
       // Calculate the loop net flux
       float currentNetFlux = CalculateNetFlux();
       PositiveFlux = CalculatePositiveFlux();
-      NegativeFlux = CalculatePositiveFlux();
+      NegativeFlux = CalculateNegativeFlux();
       float absFlux = Mathf.Abs(currentNetFlux);
 
       AllocateFlux(PositiveFlux);


### PR DESCRIPTION
Small fix to correct the value used in the OverlayLoop (https://github.com/post-kerbin-mining-corporation/SystemHeat/blob/480a68885555d9e1820da869c2656ef2a2f3f885/SystemHeat/SystemHeat/UI/Overlay/OverlayLoop.cs#L51)